### PR TITLE
Fix return type in Row::jsonSerialize() and Cell::jsonSerialize() met…

### DIFF
--- a/src/Table/Cell.php
+++ b/src/Table/Cell.php
@@ -52,7 +52,7 @@ class Cell implements JsonSerializable
         return $this;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize():array
     {
         return [
             'data'      =>  $this->data,

--- a/src/Table/Row.php
+++ b/src/Table/Row.php
@@ -36,7 +36,7 @@ class Row implements JsonSerializable
         return $this;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize():array
     {
         return [
             'columns'   =>  $this->columns,


### PR DESCRIPTION
This pull request addresses the warning message related to the return type of the jsonSerialize() method in the Row class of the Whitespacecode\TableCard\Table module. The warning indicated that the return type should be compatible with JsonSerializable::jsonSerialize(): mixed.

Please review this pull request and merge it into the main branch